### PR TITLE
Fix default class export

### DIFF
--- a/src/flowgraph.js
+++ b/src/flowgraph.js
@@ -66,7 +66,7 @@ define(function (require, exports) {
                 case 'ClassDeclaration':
                     var body = nd.body.body;
                     for (var i = 0; i < body.length; ++i)
-                        if (body[i].kind === 'constructor')
+                        if (body[i].kind === 'constructor' && nd.id)
                             flow_graph.addEdge(funcVertex(body[i].value), vertexFor(nd.id));
                     break;
 

--- a/src/module.js
+++ b/src/module.js
@@ -289,12 +289,18 @@ Todo:
 function connectDefaultImport(expFuncs, fg, srcFname, idNode) {
     if (!(srcFname in expFuncs))
         return;
-
     for (let expr of expFuncs[srcFname]['default']) {
-        if (expr.type === 'FunctionDeclaration')
+        if (expr.type === 'FunctionDeclaration') {
             fg.addEdge(flowgraph.funcVertex(expr), flowgraph.vertexFor(idNode));
-        else
-            fg.addEdge(flowgraph.vertexFor(expr), flowgraph.vertexFor(idNode));
+        } else if (expr.type === 'ClassDeclaration') {
+            let body = expr.body.body
+            for (var i = 0; i < body.length; ++i)
+              if (body[i].kind === 'constructor') {
+                  fg.addEdge(flowgraph.funcVertex(body[i].value), flowgraph.vertexFor(idNode));
+                }
+        } else {
+          fg.addEdge(flowgraph.vertexFor(expr), flowgraph.vertexFor(idNode));
+        }
     }
 }
 

--- a/tests/classes/anonymous-class.js
+++ b/tests/classes/anonymous-class.js
@@ -1,0 +1,5 @@
+export default class {
+  constructor () {
+    this.p = 0;
+  }
+}

--- a/tests/classes/import-anonymous-class.js
+++ b/tests/classes/import-anonymous-class.js
@@ -1,0 +1,3 @@
+import a from 'anonymous-class';
+
+var x = new a();

--- a/tests/classes/import-anonymous-class.truth
+++ b/tests/classes/import-anonymous-class.truth
@@ -1,0 +1,1 @@
+import-anonymous-class.js:global:3 -> anonymous-class.js:constructor:2


### PR DESCRIPTION
Adds logic for exporting a class without an ID.

For example:
```
export default class {
  constructor () {
    this.p = 0;
  }
}
```