### PR TITLE
Reverse line diff calculation

### DIFF
--- a/tests/process.py
+++ b/tests/process.py
@@ -42,8 +42,8 @@ def precision_recall(test_file, expected_output):
     difference = output_lines ^ expected_lines
 
     if len(difference) != 0:
-        extra_output = expected_lines - output_lines
-        missing_output = output_lines - expected_lines
+        missing_output = expected_lines - output_lines
+        extra_output = output_lines - expected_lines
 
         print()
 


### PR DESCRIPTION
Reverses the diff output when incorrect output is provided.

extra output is the actual output lines without the expected lines (not vise versa)
similarly for missing output